### PR TITLE
Timing tags

### DIFF
--- a/core/components/queeg/elements/plugins/queeg.plugin.php
+++ b/core/components/queeg/elements/plugins/queeg.plugin.php
@@ -88,6 +88,13 @@ if ($modx->getOption('queeg.active', null, true)) {
                     $contentArray[$key] = $data;
                 }
 
+                // Timing tags
+                // TODO: lexicon
+                $totalTime = microtime(true) - $modx->startTime;
+                $contentArray['t'] = sprintf("%2.4f s", $totalTime);
+                $contentArray['qt'] = sprintf("%2.4f s", $modx->queryTime);
+                $contentArray['q'] = isset($modx->executedQueries) ? $modx->executedQueries : 0;
+
                 $protocol = stripos($_SERVER['SERVER_PROTOCOL'],'https') === true ? 'https://' : 'http://';
 
                 // Add system params


### PR DESCRIPTION
Added timing tags ([^t^], [^q^], [^qt^]).
Related issue: https://github.com/baoweb/modx-queeg/issues/4
![screenshot_2018-07-10_10-58-23](https://user-images.githubusercontent.com/5341208/42496954-51b9d35a-8430-11e8-880e-5b61c3af1bfd.png)
